### PR TITLE
Updated project for Couchbase SDK 2.X (currently 2.2.2.0)

### DIFF
--- a/serilog-sinks-couchbase.sln
+++ b/serilog-sinks-couchbase.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Couchbase", "src\Serilog.Sinks.Couchbase\Serilog.Sinks.Couchbase.csproj", "{104D5B1E-47BE-4739-A183-08C35BF4D38D}"
 EndProject

--- a/src/Serilog.Sinks.Couchbase/LoggerConfigurationCouchBaseExtensions.cs
+++ b/src/Serilog.Sinks.Couchbase/LoggerConfigurationCouchBaseExtensions.cs
@@ -19,6 +19,8 @@ using Serilog.Sinks.Couchbase;
 
 namespace Serilog
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// Adds the WriteTo.Couchbase() extension method to <see cref="LoggerConfiguration"/>.
     /// </summary>
@@ -30,6 +32,7 @@ namespace Serilog
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="couchbaseUriList">A list of a Couchbase database servers.</param>
         /// <param name="bucketName">The bucket to store batches in.</param>
+        /// <param name="bucketPassword">The password for the specified bucket.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
@@ -38,22 +41,23 @@ namespace Serilog
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Couchbase(
             this LoggerSinkConfiguration loggerConfiguration,
-            string[] couchbaseUriList, 
+            List<Uri> couchbaseUriList, 
             string bucketName, 
+            string bucketPassword = "",
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = CouchbaseSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
-            if (couchbaseUriList == null) throw new ArgumentNullException("couchbaseUriList");
-            if (couchbaseUriList.Length == 0) throw new ArgumentException("couchbaseUriList");
-            if (couchbaseUriList[0] == null) throw new ArgumentNullException("couchbaseUriList");
-            if (bucketName == null) throw new ArgumentNullException("bucketName");
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (couchbaseUriList == null) throw new ArgumentNullException(nameof(couchbaseUriList));
+            if (couchbaseUriList.Count == 0) throw new ArgumentException(nameof(couchbaseUriList));
+            if (couchbaseUriList[0] == null) throw new ArgumentNullException(nameof(couchbaseUriList));
+            if (bucketName == null) throw new ArgumentNullException(nameof(bucketName));
 
             var defaultedPeriod = period ?? CouchbaseSink.DefaultPeriod;
             return loggerConfiguration.Sink(
-                new CouchbaseSink(couchbaseUriList, bucketName, batchPostingLimit, defaultedPeriod, formatProvider),
+                new CouchbaseSink(couchbaseUriList, bucketName, bucketPassword, batchPostingLimit, defaultedPeriod, formatProvider),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Couchbase/Serilog.Sinks.Couchbase.csproj
+++ b/src/Serilog.Sinks.Couchbase/Serilog.Sinks.Couchbase.csproj
@@ -33,26 +33,32 @@
     <DocumentationFile>bin\Release\Serilog.Sinks.Couchbase.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Couchbase">
-      <HintPath>..\..\packages\CouchbaseNetClient.1.3.4\lib\net40\Couchbase.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Enyim.Caching">
-      <HintPath>..\..\packages\CouchbaseNetClient.1.3.4\lib\net40\Enyim.Caching.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Serilog.Sinks.Couchbase/Sinks/Couchbase/CouchbaseSink.cs
+++ b/src/Serilog.Sinks.Couchbase/Sinks/Couchbase/CouchbaseSink.cs
@@ -14,22 +14,30 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Sinks.PeriodicBatching;
-using Couchbase.Extensions;
-using Couchbase.Management;
 using LogEvent = Serilog.Sinks.Couchbase.Data.LogEvent;
 
 namespace Serilog.Sinks.Couchbase
 {
+    using System.Linq;
+    using global::Couchbase;
+    using global::Couchbase.Configuration;
+    using global::Couchbase.Configuration.Client;
+    using global::Couchbase.Core;
+
     /// <summary>
     /// Writes log events as documents to a Couchbase database.
     /// </summary>
     public class CouchbaseSink : PeriodicBatchingSink
     {
         readonly IFormatProvider _formatProvider;
-        readonly global::Couchbase.CouchbaseClient _couchbaseClient;
+
+        private readonly Cluster _couchbaseCluster;
+
+        private readonly string _bucketName;
+
+        private readonly string _bucketPassword;
 
         /// <summary>
         /// A reasonable default for the number of events posted in
@@ -50,26 +58,55 @@ namespace Serilog.Sinks.Couchbase
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public CouchbaseSink(string[] couchbaseUriList, string bucketName, int batchPostingLimit, TimeSpan period, IFormatProvider formatProvider)
+        /// <param name="bucketPassword"></param>
+        public CouchbaseSink(List<Uri> couchbaseUriList, string bucketName, string bucketPassword, int batchPostingLimit, TimeSpan period, IFormatProvider formatProvider)
             : base(batchPostingLimit, period)
         {
-            if (couchbaseUriList == null) throw new ArgumentNullException("couchbaseUriList");
-            if (couchbaseUriList.Length == 0) throw new ArgumentException("couchbaseUriList");
-            if (couchbaseUriList[0] == null) throw new ArgumentNullException("couchbaseUriList");
+            if (couchbaseUriList == null) throw new ArgumentNullException(nameof(couchbaseUriList));
+            if (couchbaseUriList.Count == 0) throw new ArgumentException(nameof(couchbaseUriList));
+            if (couchbaseUriList[0] == null) throw new ArgumentNullException(nameof(couchbaseUriList));
 
-            if (bucketName == null) throw new ArgumentNullException("bucketName");
+            if (bucketName == null) throw new ArgumentNullException(nameof(bucketName));
 
-            var config = new global::Couchbase.Configuration.CouchbaseClientConfiguration();
-            
+            var config = new ClientConfiguration();
+
+            // Clearing servers here because for some reason it's trying to auto-add localhost:8091/pools
+            config.Servers.Clear();
+
             foreach (var uri in couchbaseUriList)
-                config.Urls.Add(new Uri(uri));
-            config.Bucket = bucketName;
+                config.Servers.Add(uri);
 
-            var cluster = new CouchbaseCluster(config);
-            Bucket bucket;
-            if (!cluster.TryGetBucket(bucketName, out bucket)) throw new InvalidOperationException("bucket '"+ bucketName  +"' does not exist");
+            var cluster = new Cluster(config);
 
-            _couchbaseClient = new global::Couchbase.CouchbaseClient(config);
+            IBucket bucket = null;
+
+            try
+            {
+                // Not using BucketConfigs property off of the Cluster because the OpenBucket method is not
+                // accepting 0 arguments in 2.2.2.0 of the Couchbase SDK as it is documented that it should.
+                bucket = cluster.OpenBucket(bucketName, bucketPassword);
+            }
+            catch(CouchbaseBootstrapException exception)
+            {
+                throw new InvalidOperationException(exception.InnerException.Message);
+            }
+            finally
+            {
+                if (bucket != null)
+                {
+                    cluster.CloseBucket(bucket);
+                }
+                else
+                {
+                    throw new InvalidOperationException("bucket '" + bucketName + "' does not exist");
+                }
+            }
+
+            _bucketName = bucketName;
+
+            _bucketPassword = bucketPassword;
+
+            _couchbaseCluster = cluster;
 
             _formatProvider = formatProvider;
         }
@@ -85,7 +122,7 @@ namespace Serilog.Sinks.Couchbase
             base.Dispose(disposing);
 
             if (disposing)
-                _couchbaseClient.Dispose();
+                _couchbaseCluster.Dispose();
         }
 
         /// <summary>
@@ -99,15 +136,27 @@ namespace Serilog.Sinks.Couchbase
             // This sink doesn't actually write batches, instead only using
             // the PeriodicBatching infrastructure to manage background work.
             // Probably needs modification.
+            IBucket bucket = null;
 
-            foreach (var logEvent in events)
+            try
             {
-                var key = Guid.NewGuid().ToString();
-                
-                var result = _couchbaseClient.StoreJson(Enyim.Caching.Memcached.StoreMode.Add, key, new LogEvent(logEvent, logEvent.RenderMessage(_formatProvider)));
+                bucket = _couchbaseCluster.OpenBucket(_bucketName, _bucketPassword);
 
-                if (!result)
+                foreach (var result in events.Select(logEvent => bucket.Insert(new Document<LogEvent>
+                                                                               {
+                                                                                   Id = Guid.NewGuid().ToString(),
+                                                                                   Content = new LogEvent(logEvent, logEvent.RenderMessage(_formatProvider))
+                                                                               })).Where(result => !result.Success))
+                {
                     SelfLog.WriteLine("Failed to store value");
+                }
+            }
+            finally
+            {
+                if (bucket != null)
+                {
+                    _couchbaseCluster.CloseBucket(bucket);
+                }
             }
         }
     }

--- a/src/Serilog.Sinks.Couchbase/app.config
+++ b/src/Serilog.Sinks.Couchbase/app.config
@@ -4,7 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Serilog.Sinks.Couchbase/packages.config
+++ b/src/Serilog.Sinks.Couchbase/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CouchbaseNetClient" version="1.3.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated Couchbase Sink to support the 2.X version of the Couchbase SDK.
Also added an optional bucket password parameter to support protected
buckets.

Also updated Newtonsoft.Json and Serilog libraries to latest version
from Nuget.

With all the configuration options available in the Couchbase 2.X SDK, it may be better to also update the extension to accept a Couchbase configuration item versus just bucket name and (optional) bucket password.
